### PR TITLE
Commit init keys to solace labs - clarified documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ see [Initializing-Config-Keys-With-Cloud-Init]( http://docs.solace.com/Solace-VM
 To initialise your VMR with HA group configuration, set the additional variable baseroutername to the base name of your choosing for all 3 VMRs and follow the following naming convention for your VMRs (and config keys).
 - monitor node = ${baseroutername}0
 - primary node = ${baseroutername}1
-- backup node  = ${baseroutername}2  
+- backup node  = ${baseroutername}2
+ 
 [All router names need to be based on the baseroutername followed by an index of 0, 1 or 2 as suffix]  
 Please note that dashes or underscores are not allowed in your baseroutername or routername and the script will fail to find your config-keys, if you attempt to use them in your names!
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ Now hit the "Create" button on the bottom of this page or add some VMR config ke
 You can use VMR configuration keys to initialise your VMR. All keys introduced with v8.4 are supported except for service_semp_port, username&lowbar;&lt;name&gt;&lowbar;... and interface&lowbar;&lt;ip&lowbar;intf&gt;&lowbar;. . .
 see [Initializing-Config-Keys-With-Cloud-Init]( http://docs.solace.com/Solace-VMR-Set-Up/Initializing-Config-Keys-With-Cloud-Init.htm) for a full list.  
 To initialise your VMR with HA group configuration, set the additional variable baseroutername to the base name of your choosing for all 3 VMRs and follow the following naming convention for your VMRs (and config keys).
-- monitor node = baseroutername_0
-- primary node = baseroutername_1
-- backup node  = baseroutername_2  
+- monitor node = ${baseroutername}0
+- primary node = ${baseroutername}1
+- backup node  = ${baseroutername}2  
+[All router names need to be based on the baseroutername followed by an index of 0,1 or 2 as suffix]  
 Please note that dashes or underscores are not allowed in your baseroutername or routername and the script will fail to find your config-keys, if you attempt to use them in your names!
 
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To initialise your VMR with HA group configuration, set the additional variable 
 - monitor node = ${baseroutername}0
 - primary node = ${baseroutername}1
 - backup node  = ${baseroutername}2  
-[All router names need to be based on the baseroutername followed by an index of 0,1 or 2 as suffix]  
+[All router names need to be based on the baseroutername followed by an index of 0, 1 or 2 as suffix]  
 Please note that dashes or underscores are not allowed in your baseroutername or routername and the script will fail to find your config-keys, if you attempt to use them in your names!
 
 


### PR DESCRIPTION
Corrected a typo and clarified the naming convention for the router nodes.