### PR TITLE
Update install-solace.sh to force PubSub+ Standard cap of 1000 maxConnections

### DIFF
--- a/scripts/install-solace.sh
+++ b/scripts/install-solace.sh
@@ -182,19 +182,19 @@ elif [ ${MEM_SIZE} -lt 12000000 ]; then
   SWAP_SIZE="2048"
 elif [ ${MEM_SIZE} -lt 29000000 ]; then
   # 10000 if 12GiB<=mem<28GiB
-  maxconnectioncount="10000"
+  maxconnectioncount="1000" # Should be 10000 per sizing calculations, but PubSub+ Standard is capped at 1000 - This is checked when starting the container on version 9.7.0.29 (probably wasn't before)
   shmsize="2g"
   ulimit_nofile="2448:42192"
   SWAP_SIZE="2048"
 elif [ ${MEM_SIZE} -lt 58000000 ]; then
   # 100000 if 28GiB<=mem<56GiB
-  maxconnectioncount="100000"
+  maxconnectioncount="1000" # Should be 100000 per sizing calculations, but PubSub+ Standard is capped at 1000 - This is checked when starting the container on version 9.7.0.29 (probably wasn't before)
   shmsize="3380m"
   ulimit_nofile="2448:222192"
   SWAP_SIZE="2048"
 else
   # 200000 if 56GiB<=mem
-  maxconnectioncount="200000"
+  maxconnectioncount="1000" # Should be 200000 per sizing calculations, but PubSub+ Standard is capped at 1000 - This is checked when starting the container on version 9.7.0.29 (probably wasn't before)
   shmsize="3380m"
   ulimit_nofile="2448:422192"
   SWAP_SIZE="2048"


### PR DESCRIPTION
Forced a maxconnectioncount to 1000 even on systems with more than 12 GiB, as this cap is now (version 9.7.0.29) checked when the PubSub+ Standard container is started, failing if it detects the container's environment variable setting to larger than 1000 connections.

Install log excerpt:
2020-10-11T08:43:13Z machine-name /usr/sbin/confd[69]: ERROR "Solace PubSub+ Standard Edition does not support 10000 connections.\n"
2020-10-11T08:43:13Z machine.name  /usr/sbin/confd[69]: ERROR Config check failed: exit status 1

This was not an issue with version 9.6.0.38.